### PR TITLE
Small improvements in readdata

### DIFF
--- a/konsta_cta/readdata.py
+++ b/konsta_cta/readdata.py
@@ -43,10 +43,10 @@ class FileReader():
     def get_file_list(cls, directory=None, datatype=None, max_events=None):
         if directory is None:
             raise IOError("No directory given")
-        if os.path.isdir(directory):
+        elif os.path.isdir(directory):
             # we are passing a directory, get the list of simtel files
             file_list = glob.glob("%s/*run*simtel*.{simtel,gz}" % directory)
-        else if len(glob.glob(directory))>0:
+        elif len(glob.glob(directory))>0:
             # assume we are passing a file list with wildcards
             file_list = glob.glob(directory)
         else:

--- a/konsta_cta/readdata.py
+++ b/konsta_cta/readdata.py
@@ -50,7 +50,7 @@ class FileReader():
             # assume we are passing a file list with wildcards
             file_list = glob.glob(directory)
         else:
-            warnings.warning("No simtel files found within the given wildcards/directory")
+            warnings.warn("No simtel files found within the given wildcards/directory")
 
         return cls(file_list, datatype, max_events)
 


### PR DESCRIPTION
Use the pythonic glob instead of os.popen
Allow to use wildcards.

Example:

```
protons = FileReader.get_file_list("%s/proton_*simtel.gz" %mcdatadir, "Proton", max_events=max_events)
electrons = FileReader.get_file_list("%s/electron_*simtel.gz" %mcdatadir, "Electron", max_events=max_events)
gamma_cone = FileReader.get_file_list("%s/gamma_*NGFD_cone10.simtel.gz" %mcdatadir, "Gamma_Cone", max_events=max_events)
gamma_onSource = FileReader.get_file_list("%s/gamma_*NGFD_cone10.simtel.gz" %mcdatadir, "Gamma_onSource", max_events=max_events)
```